### PR TITLE
Fix sponsorlink showing outside of connect form

### DIFF
--- a/static/plugins/freenode/freenode.css
+++ b/static/plugins/freenode/freenode.css
@@ -14,10 +14,10 @@
 }
 
 @media screen and (max-width: 850px) {
-    .fn-sponsor, .fn-sponsor a {
-	bottom: -40px;
+    .kiwi-welcome-simple-form {
+	    height: 102%;
     }
     .fn-sponsor:hover {
-	background: #fff;
+	    background: #fff;
     }
 }


### PR DESCRIPTION
102% gives some spacing above the sponsor link which is nicer to look at, but 100% works as well

There is probably a better way to do this... But hey, it works good enough I think