### PR TITLE
freenode plugin: disable image embeds by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,9 @@ window.kiwiConfig = function() {
             "infoContent": "<img src=\"static/plugins/freenode/fn-logo.svg\"><p>You have stumbled upon the <a href=\"https://kiwiirc.com\">Kiwi</a> Webchat for the freenode project.<br> To learn more about the freenode IRC network, the freenode #live conference and other freenode projects head over to <a href=\"https://freenode.net\">our website</a>.</p><p></p>",
             "allowNoChannel": true
         },
+        "buffers": {
+            "inline_link_auto_previews": false
+        },
         "embedly": {
             "key": ""
         },


### PR DESCRIPTION
fixes #28 

There is a possibility here that the setting would get overwritten each time you start kiwi, which would be sub-optimal